### PR TITLE
Set up CI/CD pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,59 @@ jobs:
               with:
                   go-version: '1.24'
 
-            - name: Build services
-              run: make build
+            - name: Build Go binaries
+              run: |
+                  cd services/gateway && go build -o gateway ./cmd/
+                  cd ../analyzer && go build -o analyzer ./cmd/
+                  cd ../processor && go build -o processor ./cmd/
+
+    docker:
+        name: Build Docker Images
+        runs-on: ubuntu-latest
+        needs: [lint, test]
+        strategy:
+            matrix:
+                service: [gateway, analyzer, processor]
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Build Gateway Docker image
+              if: matrix.service == 'gateway'
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  file: ./docker/Dockerfile.service
+                  build-args: |
+                      SERVICE=gateway
+                  push: false
+                  tags: photo-tags-gateway:latest
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+
+            - name: Build Analyzer Docker image
+              if: matrix.service == 'analyzer'
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  file: ./docker/Dockerfile.service
+                  build-args: |
+                      SERVICE=analyzer
+                  push: false
+                  tags: photo-tags-analyzer:latest
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+
+            - name: Build Processor Docker image
+              if: matrix.service == 'processor'
+              uses: docker/build-push-action@v5
+              with:
+                  context: ./services/processor
+                  file: ./services/processor/Dockerfile
+                  push: false
+                  tags: photo-tags-processor:latest
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max


### PR DESCRIPTION
Enhanced the CI workflow to build Docker images for all three services:
- Added docker job with matrix strategy for gateway, analyzer, and processor
- Configured Docker Buildx for optimized builds
- Enabled GitHub Actions caching for faster subsequent builds
- Updated build job to directly build Go binaries instead of using make build
- All Docker images are built but not pushed (CI verification only)

The workflow now performs:
1. Linting with golangci-lint for all services
2. Running tests with race detection
3. Building Go binaries
4. Building Docker images for each service