### PR TITLE
Add local deployment scripts and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,10 @@ go.work.sum
 
 # env file
 .env
+.env.local
+
+# Local deployment data
+tmp/
+logs/
+bin/
+*.pid

--- a/Makefile
+++ b/Makefile
@@ -127,3 +127,40 @@ deps-clean: ## Clean and reinstall dependencies
 	@cd services/processor && $(GOCMD) clean -modcache && $(GOCMD) mod download && $(GOCMD) mod tidy
 	@cd pkg && $(GOCMD) clean -modcache && $(GOCMD) mod download && $(GOCMD) mod tidy
 	@echo "$(GREEN)Dependencies cleaned and reinstalled!$(RESET)"
+
+##@ Local Deployment
+
+.PHONY: install-local
+install-local: ## Install dependencies for local deployment (no Docker)
+	@echo "$(YELLOW)Installing local dependencies...$(RESET)"
+	@./scripts/install-local.sh
+	@echo "$(GREEN)Local dependencies installed!$(RESET)"
+
+.PHONY: local-start
+local-start: ## Start all services locally (no Docker)
+	@echo "$(YELLOW)Starting services locally...$(RESET)"
+	@./scripts/run-local.sh start
+
+.PHONY: local-stop
+local-stop: ## Stop all local services
+	@echo "$(YELLOW)Stopping local services...$(RESET)"
+	@./scripts/run-local.sh stop
+
+.PHONY: local-restart
+local-restart: ## Restart all local services
+	@echo "$(YELLOW)Restarting local services...$(RESET)"
+	@./scripts/run-local.sh restart
+
+.PHONY: local-status
+local-status: ## Show status of local services
+	@./scripts/run-local.sh status
+
+.PHONY: local-logs
+local-logs: ## Tail logs of all local services
+	@./scripts/run-local.sh logs
+
+.PHONY: local-build
+local-build: ## Build services for local deployment
+	@echo "$(YELLOW)Building services for local deployment...$(RESET)"
+	@./scripts/run-local.sh build
+	@echo "$(GREEN)Services built successfully!$(RESET)"

--- a/README.md
+++ b/README.md
@@ -26,13 +26,30 @@ The Analyzer service automatically:
 
 ## Installation and Launch
 
-### Prerequisites
+### Deployment Options
+
+The service supports two deployment methods:
+
+1. **Docker Deployment** (Recommended for most users)
+   - Easier setup with consistent environment
+   - Best for development teams and production servers
+   - See [Docker Setup](#docker-deployment) below
+
+2. **Native/Local Deployment** (Recommended for Raspberry Pi and resource-constrained devices)
+   - Better performance on ARM devices
+   - Lower memory footprint
+   - Direct access to system resources
+   - See [Local Deployment Guide](docs/LOCAL_DEPLOYMENT.md)
+
+### Docker Deployment
+
+#### Prerequisites
 
 -   Docker and Docker Compose
 -   Telegram bot token (get from [@BotFather](https://t.me/BotFather))
 -   OpenRouter API key for accessing vision models (free tier available)
 
-### Starting the Project
+#### Starting the Project
 
 1. Clone the repository:
 
@@ -60,13 +77,54 @@ The Analyzer service automatically:
     ./scripts/setup.sh
     ```
 
-### Stopping Services
+#### Stopping Services
 
 To stop all services, use:
 
 ```bash
 ./scripts/stop.sh
 ```
+
+### Local/Native Deployment
+
+For running on bare metal without Docker (recommended for Raspberry Pi, macOS development, or resource-constrained environments):
+
+#### Quick Start
+
+```bash
+# 1. Install all dependencies
+./scripts/install-local.sh
+
+# 2. Configure environment
+cp config/.env.local.example config/.env.local
+# Edit config/.env.local and set TELEGRAM_TOKEN and OPENROUTER_API_KEY
+
+# 3. Start all services
+./scripts/run-local.sh start
+
+# 4. Check status
+./scripts/run-local.sh status
+```
+
+#### Platform Support
+
+- ✅ **macOS** (Intel and Apple Silicon M1/M2/M3)
+- ✅ **Linux** (Ubuntu, Debian, Raspberry Pi OS)
+- ✅ **ARM64** (Raspberry Pi 3/4, other ARM devices)
+- ✅ **x86_64** (Standard Linux servers)
+
+#### Managing Services
+
+```bash
+./scripts/run-local.sh start    # Start all services
+./scripts/run-local.sh stop     # Stop all services
+./scripts/run-local.sh restart  # Restart all services
+./scripts/run-local.sh status   # Show service status
+./scripts/run-local.sh logs     # View all logs
+./scripts/run-local.sh build    # Rebuild services
+```
+
+For detailed platform-specific instructions, troubleshooting, and configuration options, see the [Local Deployment Guide](docs/LOCAL_DEPLOYMENT.md).
 
 ## Usage
 

--- a/config/.env.local.example
+++ b/config/.env.local.example
@@ -1,0 +1,117 @@
+# Photo Tags - Local Deployment Configuration
+# Copy this file to .env.local and configure the values
+
+# =============================================================================
+# Telegram Configuration
+# =============================================================================
+# Get your bot token from @BotFather on Telegram
+TELEGRAM_TOKEN=your_telegram_bot_token_here
+
+# =============================================================================
+# RabbitMQ Configuration
+# =============================================================================
+# Default credentials for local RabbitMQ installation
+RABBITMQ_URL=amqp://user:password@localhost:5672/
+
+# Queue names
+RABBITMQ_CONSUMER_QUEUE_GATEWAY=image_upload
+RABBITMQ_PUBLISHER_QUEUE_GATEWAY=image_upload
+RABBITMQ_CONSUMER_QUEUE_ANALYZER=image_upload
+RABBITMQ_PUBLISHER_QUEUE_ANALYZER=metadata_generated
+RABBITMQ_CONSUMER_QUEUE_PROCESSOR=metadata_generated
+RABBITMQ_PUBLISHER_QUEUE_PROCESSOR=image_processed
+
+# Connection settings
+RABBITMQ_PREFETCH_COUNT=1
+RABBITMQ_RECONNECT_ATTEMPTS=5
+RABBITMQ_RECONNECT_DELAY=5s
+
+# =============================================================================
+# MinIO Configuration
+# =============================================================================
+# MinIO endpoint (do not include http://)
+MINIO_ENDPOINT=localhost:9000
+
+# MinIO credentials
+MINIO_ACCESS_KEY=minioadmin
+MINIO_SECRET_KEY=minioadmin
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin
+
+# MinIO settings
+MINIO_USE_SSL=false
+MINIO_ORIGINAL_BUCKET=original
+MINIO_PROCESSED_BUCKET=processed
+
+# MinIO timeouts
+MINIO_DOWNLOAD_TIMEOUT=30s
+MINIO_UPLOAD_TIMEOUT=30s
+MINIO_CONNECT_ATTEMPTS=5
+MINIO_CONNECT_DELAY=3s
+
+# MinIO data directory
+MINIO_DATA_DIR=$HOME/photo-tags/data/minio
+
+# =============================================================================
+# OpenRouter Configuration (for Analyzer service)
+# =============================================================================
+# Get your API key from https://openrouter.ai/
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+
+# Model selection
+# Options: openai/gpt-4o, openai/gpt-4-turbo, anthropic/claude-3-opus, etc.
+OPENROUTER_MODEL=openai/gpt-4o
+
+# Model parameters
+OPENROUTER_MAX_TOKENS=500
+OPENROUTER_TEMPERATURE=0.7
+
+# Prompt for metadata generation
+OPENROUTER_PROMPT="Generate title, description and keywords for this image. Return strictly in JSON format with fields 'title', 'description' and 'keywords'."
+
+# Use OpenRouterGo adapter (optional)
+USE_OPENROUTERGO_ADAPTER=false
+
+# Model check interval
+OPENROUTER_MODEL_CHECK_INTERVAL=24h
+
+# =============================================================================
+# ExifTool Configuration (for Processor service)
+# =============================================================================
+# Path to exiftool binary
+# macOS (Homebrew): /opt/homebrew/bin/exiftool or /usr/local/bin/exiftool
+# Linux: /usr/bin/exiftool
+EXIFTOOL_BINARY_PATH=/usr/bin/exiftool
+
+# Temporary directory for processing
+EXIFTOOL_TEMP_DIR=$HOME/photo-tags/tmp/processor
+
+# ExifTool timeout
+EXIFTOOL_COMMAND_TIMEOUT=10s
+
+# =============================================================================
+# Gateway Service Configuration
+# =============================================================================
+# HTTP server port
+SERVER_PORT=8080
+
+# =============================================================================
+# Worker Configuration
+# =============================================================================
+# Number of concurrent workers
+WORKER_CONCURRENCY=3
+
+# Maximum number of retries for failed tasks
+WORKER_MAX_RETRIES=3
+
+# Delay between retries
+WORKER_RETRY_DELAY=5s
+
+# =============================================================================
+# Logging Configuration
+# =============================================================================
+# Log level: debug, info, warn, error
+LOG_LEVEL=info
+
+# Log format: json, text
+LOG_FORMAT=text

--- a/docs/LOCAL_DEPLOYMENT.md
+++ b/docs/LOCAL_DEPLOYMENT.md
@@ -1,0 +1,688 @@
+# Local Deployment Guide
+
+This guide provides instructions for deploying the Photo Tags system locally without Docker on macOS and Linux ARM64/x86_64.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Platform-Specific Instructions](#platform-specific-instructions)
+  - [macOS](#macos)
+  - [Linux (Ubuntu/Debian)](#linux-ubuntudebian)
+  - [Linux (Raspberry Pi / ARM64)](#linux-raspberry-pi--arm64)
+- [Configuration](#configuration)
+- [Running Services](#running-services)
+- [Troubleshooting](#troubleshooting)
+- [Development](#development)
+- [Comparison: Docker vs Native](#comparison-docker-vs-native)
+
+## Prerequisites
+
+Before installing, ensure you have:
+
+- **macOS**: macOS 10.15 or later
+- **Linux**: Ubuntu 20.04+, Debian 11+, or Raspberry Pi OS
+- At least 2GB RAM
+- 5GB free disk space
+- Internet connection for downloading dependencies
+
+## Quick Start
+
+For the impatient, here's the fastest way to get started:
+
+```bash
+# 1. Clone the repository (if not already done)
+git clone https://github.com/shabohin/photo-tags.git
+cd photo-tags
+
+# 2. Install all dependencies
+./scripts/install-local.sh
+
+# 3. Configure environment
+cp config/.env.local.example config/.env.local
+# Edit config/.env.local and set your TELEGRAM_TOKEN and OPENROUTER_API_KEY
+
+# 4. Start all services
+./scripts/run-local.sh start
+
+# 5. Check status
+./scripts/run-local.sh status
+
+# 6. View logs
+./scripts/run-local.sh logs
+```
+
+## Platform-Specific Instructions
+
+### macOS
+
+#### Installation
+
+The installation script will automatically use Homebrew to install dependencies.
+
+```bash
+# Run the installation script
+./scripts/install-local.sh
+```
+
+This will install:
+- **Go** 1.22+ (via Homebrew)
+- **ExifTool** (via Homebrew)
+- **RabbitMQ** (via Homebrew)
+- **MinIO** (via Homebrew)
+
+#### Starting Services
+
+```bash
+# Start all services
+./scripts/run-local.sh start
+```
+
+#### Stopping Services
+
+```bash
+# Stop all services
+./scripts/run-local.sh stop
+```
+
+#### Service Management
+
+On macOS, RabbitMQ is managed via Homebrew services:
+
+```bash
+# Start RabbitMQ manually
+brew services start rabbitmq
+
+# Stop RabbitMQ manually
+brew services stop rabbitmq
+
+# Restart RabbitMQ
+brew services restart rabbitmq
+```
+
+MinIO runs as a background process managed by the run-local.sh script.
+
+### Linux (Ubuntu/Debian)
+
+#### Installation
+
+```bash
+# Run the installation script
+./scripts/install-local.sh
+```
+
+This will:
+1. Download and install Go 1.22+ to `/usr/local/go`
+2. Install ExifTool via apt-get
+3. Install RabbitMQ from official repository
+4. Install MinIO to `/usr/local/bin`
+5. Create systemd service files
+
+#### Service Management
+
+On Linux, services can be managed via systemd:
+
+```bash
+# Start services via systemd
+sudo systemctl start rabbitmq-server
+sudo systemctl start minio
+
+# Enable services to start on boot
+sudo systemctl enable rabbitmq-server
+sudo systemctl enable minio
+
+# Check service status
+sudo systemctl status rabbitmq-server
+sudo systemctl status minio
+```
+
+Or use the run-local.sh script:
+
+```bash
+# Start all services (including application services)
+./scripts/run-local.sh start
+
+# Stop all services
+./scripts/run-local.sh stop
+```
+
+#### Post-Installation
+
+After installation, you may need to reload your shell to update PATH:
+
+```bash
+source ~/.bashrc
+```
+
+Or open a new terminal session.
+
+### Linux (Raspberry Pi / ARM64)
+
+#### Installation on Raspberry Pi
+
+The installation script automatically detects ARM64 architecture and installs compatible binaries.
+
+```bash
+# Run the installation script
+./scripts/install-local.sh
+```
+
+**Note**: On Raspberry Pi, especially with 1-2GB RAM, you may want to reduce worker concurrency:
+
+```bash
+# Edit config/.env.local
+WORKER_CONCURRENCY=1
+```
+
+#### Performance Considerations
+
+For Raspberry Pi 3/4:
+- Use `WORKER_CONCURRENCY=1` or `2`
+- Set `LOG_LEVEL=warn` to reduce I/O
+- Consider using an external SSD instead of SD card for better performance
+- Ensure adequate cooling to prevent thermal throttling
+
+#### Memory Optimization
+
+```bash
+# In config/.env.local
+WORKER_CONCURRENCY=1
+RABBITMQ_PREFETCH_COUNT=1
+OPENROUTER_MODEL=openai/gpt-4o-mini  # Use smaller/cheaper model
+```
+
+## Configuration
+
+### 1. Copy the Example Configuration
+
+```bash
+cp config/.env.local.example config/.env.local
+```
+
+### 2. Edit Configuration
+
+Edit `config/.env.local` and set the required values:
+
+#### Required Configuration
+
+```bash
+# Telegram Bot Token (get from @BotFather)
+TELEGRAM_TOKEN=1234567890:ABCdefGHIjklMNOpqrsTUVwxyz
+
+# OpenRouter API Key (get from https://openrouter.ai/)
+OPENROUTER_API_KEY=sk-or-v1-abc123...
+```
+
+#### Optional Configuration
+
+```bash
+# RabbitMQ (default values work for local installation)
+RABBITMQ_URL=amqp://user:password@localhost:5672/
+
+# MinIO (default values work for local installation)
+MINIO_ENDPOINT=localhost:9000
+MINIO_ACCESS_KEY=minioadmin
+MINIO_SECRET_KEY=minioadmin
+
+# Worker Settings
+WORKER_CONCURRENCY=3  # Adjust based on your CPU
+
+# Logging
+LOG_LEVEL=info  # debug, info, warn, error
+LOG_FORMAT=text  # text or json
+```
+
+### 3. Platform-Specific Configuration
+
+#### macOS (Apple Silicon M1/M2/M3)
+
+```bash
+# ExifTool path (Homebrew on Apple Silicon)
+EXIFTOOL_BINARY_PATH=/opt/homebrew/bin/exiftool
+```
+
+#### macOS (Intel)
+
+```bash
+# ExifTool path (Homebrew on Intel)
+EXIFTOOL_BINARY_PATH=/usr/local/bin/exiftool
+```
+
+#### Linux
+
+```bash
+# ExifTool path (standard location)
+EXIFTOOL_BINARY_PATH=/usr/bin/exiftool
+```
+
+## Running Services
+
+### Start All Services
+
+```bash
+./scripts/run-local.sh start
+```
+
+This will:
+1. Start RabbitMQ
+2. Start MinIO
+3. Build services (if needed)
+4. Start Gateway service
+5. Start Analyzer service
+6. Start Processor service
+
+### Stop All Services
+
+```bash
+./scripts/run-local.sh stop
+```
+
+### Restart Services
+
+```bash
+./scripts/run-local.sh restart
+```
+
+### Check Status
+
+```bash
+./scripts/run-local.sh status
+```
+
+Example output:
+```
+Service Status:
+
+  ● RabbitMQ       - running
+  ● MinIO          - running
+  ● gateway        - running (PID: 12345)
+  ● analyzer       - running (PID: 12346)
+  ● processor      - running (PID: 12347)
+
+Service URLs:
+  Gateway:          http://localhost:8080
+  RabbitMQ UI:      http://localhost:15672 (user/password)
+  MinIO Console:    http://localhost:9001 (minioadmin/minioadmin)
+
+Logs directory: /path/to/photo-tags/logs
+```
+
+### View Logs
+
+```bash
+# Tail all service logs
+./scripts/run-local.sh logs
+
+# View specific service log
+tail -f logs/gateway.log
+tail -f logs/analyzer.log
+tail -f logs/processor.log
+```
+
+### Rebuild Services
+
+```bash
+./scripts/run-local.sh build
+```
+
+## Service URLs
+
+After starting the services, you can access:
+
+| Service | URL | Credentials |
+|---------|-----|-------------|
+| Gateway API | http://localhost:8080 | - |
+| RabbitMQ Management | http://localhost:15672 | user / password |
+| MinIO Console | http://localhost:9001 | minioadmin / minioadmin |
+
+## Troubleshooting
+
+### Services Won't Start
+
+1. Check if ports are already in use:
+   ```bash
+   # Check port usage
+   lsof -i :5672  # RabbitMQ
+   lsof -i :15672 # RabbitMQ Management
+   lsof -i :9000  # MinIO API
+   lsof -i :9001  # MinIO Console
+   lsof -i :8080  # Gateway
+   ```
+
+2. Check service logs:
+   ```bash
+   tail -f logs/*.log
+   ```
+
+3. Verify configuration:
+   ```bash
+   cat config/.env.local
+   ```
+
+### RabbitMQ Issues
+
+#### Connection Refused
+
+```bash
+# Check if RabbitMQ is running
+# macOS:
+brew services list | grep rabbitmq
+
+# Linux:
+sudo systemctl status rabbitmq-server
+
+# Start RabbitMQ manually
+# macOS:
+brew services start rabbitmq
+
+# Linux:
+sudo systemctl start rabbitmq-server
+```
+
+#### Create User Manually
+
+```bash
+# Add user
+sudo rabbitmqctl add_user user password
+
+# Set permissions
+sudo rabbitmqctl set_permissions -p / user ".*" ".*" ".*"
+
+# Set user tags
+sudo rabbitmqctl set_user_tags user administrator
+```
+
+### MinIO Issues
+
+#### MinIO Won't Start
+
+```bash
+# Check if data directory exists and is writable
+ls -la ~/photo-tags/data/minio
+
+# Create if missing
+mkdir -p ~/photo-tags/data/minio
+
+# Start MinIO manually
+MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin \
+  minio server ~/photo-tags/data/minio --console-address ":9001"
+```
+
+#### Create Buckets Manually
+
+```bash
+# Configure mc (MinIO client)
+mc alias set local http://localhost:9000 minioadmin minioadmin
+
+# Create buckets
+mc mb local/original
+mc mb local/processed
+
+# List buckets
+mc ls local
+```
+
+### ExifTool Not Found
+
+```bash
+# Find exiftool location
+which exiftool
+
+# macOS (Homebrew):
+# Apple Silicon: /opt/homebrew/bin/exiftool
+# Intel: /usr/local/bin/exiftool
+
+# Linux:
+# Usually: /usr/bin/exiftool
+
+# Update config/.env.local with the correct path
+EXIFTOOL_BINARY_PATH=/path/to/exiftool
+```
+
+### Go Not Found
+
+```bash
+# Check Go installation
+go version
+
+# If not found, ensure PATH is set
+# Add to ~/.bashrc or ~/.zshrc:
+export PATH=$PATH:/usr/local/go/bin
+export PATH=$PATH:$HOME/go/bin
+
+# Reload shell
+source ~/.bashrc  # or ~/.zshrc
+```
+
+### Low Memory Issues (Raspberry Pi)
+
+If you experience crashes or OOM (Out of Memory) errors:
+
+```bash
+# Reduce worker concurrency in config/.env.local
+WORKER_CONCURRENCY=1
+
+# Use a smaller AI model
+OPENROUTER_MODEL=openai/gpt-4o-mini
+
+# Reduce RabbitMQ prefetch
+RABBITMQ_PREFETCH_COUNT=1
+
+# Consider increasing swap
+sudo dphys-swapfile swapoff
+sudo nano /etc/dphys-swapfile  # Set CONF_SWAPSIZE=2048
+sudo dphys-swapfile setup
+sudo dphys-swapfile swapon
+```
+
+## Development
+
+### Building Individual Services
+
+```bash
+# Build Gateway
+cd services/gateway
+go build -o ../../bin/gateway cmd/main.go
+
+# Build Analyzer
+cd services/analyzer
+go build -o ../../bin/analyzer cmd/main.go
+
+# Build Processor
+cd services/processor
+go build -o ../../bin/processor cmd/main.go
+```
+
+### Running Individual Services
+
+```bash
+# Source configuration
+set -a
+source config/.env.local
+set +a
+
+# Run Gateway
+./bin/gateway
+
+# Run Analyzer
+./bin/analyzer
+
+# Run Processor
+./bin/processor
+```
+
+### Development Mode
+
+For development, you can use text logging instead of JSON:
+
+```bash
+# In config/.env.local
+LOG_LEVEL=debug
+LOG_FORMAT=text
+```
+
+## Comparison: Docker vs Native
+
+### When to Use Docker
+
+✅ **Pros:**
+- Easier setup and consistent environment
+- Isolated dependencies
+- Easier to replicate production environment
+- Better for development on teams
+
+❌ **Cons:**
+- Higher resource usage (especially on ARM)
+- Additional layer of complexity
+- May have performance overhead
+
+### When to Use Native Deployment
+
+✅ **Pros:**
+- Better performance (especially on Raspberry Pi)
+- Lower memory usage
+- Direct access to system resources
+- Easier debugging
+
+❌ **Cons:**
+- Platform-specific setup
+- Dependency management
+- Potential conflicts with system packages
+
+### Recommendation
+
+| Platform | Recommendation | Reason |
+|----------|---------------|---------|
+| **Raspberry Pi 3/4** | Native | Better performance, lower memory usage |
+| **macOS (Development)** | Docker or Native | Either works well, choose based on preference |
+| **Linux Server (Production)** | Docker | Easier deployment and isolation |
+| **Limited RAM (<4GB)** | Native | Lower memory footprint |
+
+## File Locations
+
+### Data Directories
+
+```bash
+~/photo-tags/data/minio      # MinIO data
+~/photo-tags/tmp/processor   # Temporary processing files
+```
+
+### Log Files
+
+```bash
+logs/gateway.log     # Gateway service logs
+logs/analyzer.log    # Analyzer service logs
+logs/processor.log   # Processor service logs
+logs/minio.log       # MinIO logs
+```
+
+### PID Files
+
+```bash
+tmp/pids/gateway.pid    # Gateway process ID
+tmp/pids/analyzer.pid   # Analyzer process ID
+tmp/pids/processor.pid  # Processor process ID
+tmp/pids/minio.pid      # MinIO process ID
+```
+
+### Binaries
+
+```bash
+bin/gateway     # Gateway binary
+bin/analyzer    # Analyzer binary
+bin/processor   # Processor binary
+```
+
+## Security Considerations
+
+### For Production Use
+
+If deploying to a production environment, consider:
+
+1. **Change Default Credentials**:
+   ```bash
+   # In config/.env.local
+   RABBITMQ_URL=amqp://custom_user:strong_password@localhost:5672/
+   MINIO_ACCESS_KEY=custom_access_key
+   MINIO_SECRET_KEY=strong_secret_key
+   ```
+
+2. **Enable TLS/SSL**:
+   ```bash
+   MINIO_USE_SSL=true
+   ```
+
+3. **Firewall Rules**:
+   ```bash
+   # Only allow localhost connections
+   sudo ufw allow from 127.0.0.1 to any port 5672
+   sudo ufw allow from 127.0.0.1 to any port 9000
+   ```
+
+4. **Use Environment-Specific Configs**:
+   - Development: `config/.env.local`
+   - Production: `config/.env.production` (not in git)
+
+## Uninstalling
+
+To remove all installed components:
+
+### macOS
+
+```bash
+# Stop services
+./scripts/run-local.sh stop
+
+# Remove Homebrew packages
+brew uninstall rabbitmq minio exiftool go
+
+# Remove data directories
+rm -rf ~/photo-tags/data
+rm -rf ~/photo-tags/logs
+rm -rf ~/photo-tags/tmp
+```
+
+### Linux
+
+```bash
+# Stop services
+./scripts/run-local.sh stop
+
+# Remove packages (Ubuntu/Debian)
+sudo apt-get remove --purge rabbitmq-server libimage-exiftool-perl
+
+# Remove MinIO and Go
+sudo rm /usr/local/bin/minio
+sudo rm /usr/local/bin/mc
+sudo rm -rf /usr/local/go
+
+# Remove systemd service
+sudo systemctl disable minio
+sudo rm /etc/systemd/system/minio.service
+sudo systemctl daemon-reload
+
+# Remove data directories
+rm -rf ~/photo-tags/data
+rm -rf ~/photo-tags/logs
+rm -rf ~/photo-tags/tmp
+sudo rm -rf /usr/local/share/minio
+```
+
+## Additional Resources
+
+- [RabbitMQ Documentation](https://www.rabbitmq.com/documentation.html)
+- [MinIO Documentation](https://min.io/docs/minio/linux/index.html)
+- [ExifTool Documentation](https://exiftool.org/)
+- [Go Documentation](https://go.dev/doc/)
+
+## Getting Help
+
+If you encounter issues:
+
+1. Check the [Troubleshooting](#troubleshooting) section
+2. Review service logs: `./scripts/run-local.sh logs`
+3. Check service status: `./scripts/run-local.sh status`
+4. Open an issue on GitHub with:
+   - Your platform (macOS/Linux, architecture)
+   - Error messages from logs
+   - Steps to reproduce the issue

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Detect OS and Architecture
+detect_platform() {
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    ARCH=$(uname -m)
+
+    case "$OS" in
+        darwin)
+            OS="macos"
+            ;;
+        linux)
+            OS="linux"
+            ;;
+        *)
+            log_error "Unsupported OS: $OS"
+            exit 1
+            ;;
+    esac
+
+    case "$ARCH" in
+        x86_64)
+            ARCH="amd64"
+            ;;
+        aarch64|arm64)
+            ARCH="arm64"
+            ;;
+        *)
+            log_error "Unsupported architecture: $ARCH"
+            exit 1
+            ;;
+    esac
+
+    log_info "Detected platform: $OS $ARCH"
+}
+
+# Check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Install Homebrew on macOS
+install_homebrew() {
+    if [[ "$OS" != "macos" ]]; then
+        return
+    fi
+
+    if ! command_exists brew; then
+        log_info "Installing Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        log_success "Homebrew installed"
+    else
+        log_info "Homebrew already installed"
+    fi
+}
+
+# Install Go
+install_go() {
+    if command_exists go; then
+        GO_VERSION=$(go version | awk '{print $3}' | sed 's/go//')
+        log_info "Go $GO_VERSION already installed"
+        return
+    fi
+
+    log_info "Installing Go..."
+
+    if [[ "$OS" == "macos" ]]; then
+        brew install go
+    else
+        # Install Go on Linux
+        GO_VERSION="1.22.0"
+        GO_TARBALL="go${GO_VERSION}.${OS}-${ARCH}.tar.gz"
+
+        cd /tmp
+        curl -LO "https://go.dev/dl/${GO_TARBALL}"
+        sudo rm -rf /usr/local/go
+        sudo tar -C /usr/local -xzf "${GO_TARBALL}"
+        rm "${GO_TARBALL}"
+
+        # Add to PATH if not already there
+        if ! grep -q "/usr/local/go/bin" ~/.bashrc; then
+            echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
+            echo 'export PATH=$PATH:$HOME/go/bin' >> ~/.bashrc
+        fi
+
+        export PATH=$PATH:/usr/local/go/bin
+    fi
+
+    log_success "Go installed: $(go version)"
+}
+
+# Install ExifTool
+install_exiftool() {
+    if command_exists exiftool; then
+        log_info "ExifTool already installed: $(exiftool -ver)"
+        return
+    fi
+
+    log_info "Installing ExifTool..."
+
+    if [[ "$OS" == "macos" ]]; then
+        brew install exiftool
+    else
+        # Install ExifTool on Linux
+        if command_exists apt-get; then
+            sudo apt-get update
+            sudo apt-get install -y libimage-exiftool-perl
+        elif command_exists yum; then
+            sudo yum install -y perl-Image-ExifTool
+        else
+            log_warn "Package manager not found, installing from source..."
+            cd /tmp
+            curl -LO https://exiftool.org/Image-ExifTool-12.76.tar.gz
+            tar -xzf Image-ExifTool-12.76.tar.gz
+            cd Image-ExifTool-12.76
+            perl Makefile.PL
+            make
+            sudo make install
+            cd ..
+            rm -rf Image-ExifTool-12.76*
+        fi
+    fi
+
+    log_success "ExifTool installed: $(exiftool -ver)"
+}
+
+# Install RabbitMQ
+install_rabbitmq() {
+    if command_exists rabbitmq-server; then
+        log_info "RabbitMQ already installed"
+        return
+    fi
+
+    log_info "Installing RabbitMQ..."
+
+    if [[ "$OS" == "macos" ]]; then
+        brew install rabbitmq
+
+        # Add to PATH
+        if ! grep -q "/usr/local/sbin" ~/.zshrc 2>/dev/null && ! grep -q "/usr/local/sbin" ~/.bashrc 2>/dev/null; then
+            echo 'export PATH=$PATH:/usr/local/sbin' >> ~/.zshrc
+            echo 'export PATH=$PATH:/usr/local/sbin' >> ~/.bashrc
+        fi
+        export PATH=$PATH:/usr/local/sbin
+    else
+        # Install RabbitMQ on Linux
+        if command_exists apt-get; then
+            # Add RabbitMQ repository
+            sudo apt-get update
+            sudo apt-get install -y curl gnupg apt-transport-https
+
+            # Import signing key
+            curl -fsSL https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc | sudo apt-key add -
+
+            # Add repository
+            sudo tee /etc/apt/sources.list.d/rabbitmq.list <<EOF
+deb https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu $(lsb_release -cs) main
+deb-src https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu $(lsb_release -cs) main
+EOF
+
+            sudo apt-get update
+            sudo apt-get install -y rabbitmq-server
+
+            # Enable and start RabbitMQ
+            sudo systemctl enable rabbitmq-server
+            sudo systemctl start rabbitmq-server
+
+            # Enable management plugin
+            sudo rabbitmq-plugins enable rabbitmq_management
+        else
+            log_error "Unsupported package manager for RabbitMQ installation"
+            log_info "Please install RabbitMQ manually from https://www.rabbitmq.com/download.html"
+            return 1
+        fi
+    fi
+
+    log_success "RabbitMQ installed"
+}
+
+# Install MinIO
+install_minio() {
+    if command_exists minio; then
+        log_info "MinIO already installed"
+        return
+    fi
+
+    log_info "Installing MinIO..."
+
+    if [[ "$OS" == "macos" ]]; then
+        brew install minio/stable/minio
+        brew install minio/stable/mc
+    else
+        # Install MinIO on Linux
+        cd /tmp
+
+        # Download MinIO server
+        curl -LO "https://dl.min.io/server/minio/release/${OS}-${ARCH}/minio"
+        chmod +x minio
+        sudo mv minio /usr/local/bin/
+
+        # Download MinIO client (mc)
+        curl -LO "https://dl.min.io/client/mc/release/${OS}-${ARCH}/mc"
+        chmod +x mc
+        sudo mv mc /usr/local/bin/
+
+        # Create MinIO data directory
+        sudo mkdir -p /usr/local/share/minio
+        sudo chown $(whoami) /usr/local/share/minio
+
+        # Create systemd service file
+        if command_exists systemctl; then
+            sudo tee /etc/systemd/system/minio.service > /dev/null <<EOF
+[Unit]
+Description=MinIO
+Documentation=https://docs.min.io
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=$(whoami)
+Group=$(id -gn)
+WorkingDirectory=/usr/local/share/minio
+
+ExecStart=/usr/local/bin/minio server /usr/local/share/minio --console-address ":9001"
+
+# Let systemd restart this service always
+Restart=always
+
+# Specifies the maximum file descriptor number that can be opened by this process
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+            sudo systemctl daemon-reload
+            sudo systemctl enable minio
+        fi
+    fi
+
+    log_success "MinIO installed"
+}
+
+# Create necessary directories
+create_directories() {
+    log_info "Creating necessary directories..."
+
+    mkdir -p ~/photo-tags/data/minio
+    mkdir -p ~/photo-tags/data/rabbitmq
+    mkdir -p ~/photo-tags/logs
+    mkdir -p ~/photo-tags/tmp/processor
+
+    log_success "Directories created"
+}
+
+# Setup RabbitMQ user
+setup_rabbitmq() {
+    log_info "Setting up RabbitMQ..."
+
+    # Wait for RabbitMQ to start
+    sleep 5
+
+    if [[ "$OS" == "macos" ]]; then
+        # Enable management plugin
+        rabbitmq-plugins enable rabbitmq_management || true
+
+        # Create user (if not exists)
+        rabbitmqctl add_user user password 2>/dev/null || true
+        rabbitmqctl set_user_tags user administrator
+        rabbitmqctl set_permissions -p / user ".*" ".*" ".*"
+    fi
+
+    log_success "RabbitMQ configured"
+}
+
+# Main installation function
+main() {
+    log_info "Starting local installation for photo-tags..."
+    echo ""
+
+    detect_platform
+    echo ""
+
+    # Install dependencies based on platform
+    if [[ "$OS" == "macos" ]]; then
+        install_homebrew
+        echo ""
+    fi
+
+    install_go
+    echo ""
+
+    install_exiftool
+    echo ""
+
+    install_rabbitmq
+    echo ""
+
+    install_minio
+    echo ""
+
+    create_directories
+    echo ""
+
+    # Build the services
+    log_info "Building services..."
+    cd "$(dirname "$0")/.."
+    make build || {
+        log_warn "Make build failed, trying manual build..."
+        cd services/gateway && go build -o ../../bin/gateway cmd/main.go && cd ../..
+        cd services/analyzer && go build -o ../../bin/analyzer cmd/main.go && cd ../..
+        cd services/processor && go build -o ../../bin/processor cmd/main.go && cd ../..
+    }
+    log_success "Services built"
+    echo ""
+
+    log_success "Installation completed!"
+    echo ""
+    log_info "Next steps:"
+    log_info "  1. Copy config/.env.local.example to config/.env.local and configure"
+    log_info "  2. Start services with: ./scripts/run-local.sh"
+    log_info "  3. Access RabbitMQ management UI at: http://localhost:15672 (user/password)"
+    log_info "  4. Access MinIO console at: http://localhost:9001 (minioadmin/minioadmin)"
+    echo ""
+}
+
+main "$@"

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONFIG_FILE="${PROJECT_ROOT}/config/.env.local"
+PID_DIR="${PROJECT_ROOT}/tmp/pids"
+LOG_DIR="${PROJECT_ROOT}/logs"
+
+# Detect OS
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+# Check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Create necessary directories
+create_directories() {
+    mkdir -p "$PID_DIR"
+    mkdir -p "$LOG_DIR"
+    mkdir -p ~/photo-tags/data/minio
+    mkdir -p ~/photo-tags/tmp/processor
+}
+
+# Load configuration
+load_config() {
+    if [[ -f "$CONFIG_FILE" ]]; then
+        log_info "Loading configuration from $CONFIG_FILE"
+        set -a
+        source "$CONFIG_FILE"
+        set +a
+    else
+        log_warn "Configuration file not found: $CONFIG_FILE"
+        log_info "Using default configuration for localhost"
+    fi
+}
+
+# Start RabbitMQ
+start_rabbitmq() {
+    log_info "Starting RabbitMQ..."
+
+    if pgrep -f rabbitmq-server > /dev/null; then
+        log_info "RabbitMQ is already running"
+        return
+    fi
+
+    if [[ "$OS" == "darwin" ]]; then
+        # macOS - start RabbitMQ with Homebrew
+        brew services start rabbitmq
+    else
+        # Linux - start RabbitMQ with systemd
+        if command_exists systemctl; then
+            sudo systemctl start rabbitmq-server
+        else
+            # Fallback to manual start
+            rabbitmq-server -detached
+        fi
+    fi
+
+    # Wait for RabbitMQ to be ready
+    log_info "Waiting for RabbitMQ to be ready..."
+    local max_attempts=30
+    local attempt=0
+    while ! rabbitmqctl status >/dev/null 2>&1; do
+        attempt=$((attempt + 1))
+        if [ $attempt -ge $max_attempts ]; then
+            log_error "RabbitMQ failed to start"
+            return 1
+        fi
+        sleep 1
+    done
+
+    log_success "RabbitMQ started"
+}
+
+# Start MinIO
+start_minio() {
+    log_info "Starting MinIO..."
+
+    if pgrep -f "minio server" > /dev/null; then
+        log_info "MinIO is already running"
+        return
+    fi
+
+    local MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
+    local MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:-minioadmin}"
+    local MINIO_DATA_DIR="${MINIO_DATA_DIR:-$HOME/photo-tags/data/minio}"
+
+    if [[ "$OS" == "darwin" ]]; then
+        # macOS
+        MINIO_ROOT_USER="$MINIO_ROOT_USER" \
+        MINIO_ROOT_PASSWORD="$MINIO_ROOT_PASSWORD" \
+        minio server "$MINIO_DATA_DIR" --console-address ":9001" \
+            > "$LOG_DIR/minio.log" 2>&1 &
+        echo $! > "$PID_DIR/minio.pid"
+    else
+        # Linux
+        if command_exists systemctl && systemctl list-unit-files | grep -q minio.service; then
+            sudo systemctl start minio
+        else
+            # Fallback to manual start
+            MINIO_ROOT_USER="$MINIO_ROOT_USER" \
+            MINIO_ROOT_PASSWORD="$MINIO_ROOT_PASSWORD" \
+            nohup minio server "$MINIO_DATA_DIR" --console-address ":9001" \
+                > "$LOG_DIR/minio.log" 2>&1 &
+            echo $! > "$PID_DIR/minio.pid"
+        fi
+    fi
+
+    # Wait for MinIO to be ready
+    log_info "Waiting for MinIO to be ready..."
+    local max_attempts=30
+    local attempt=0
+    while ! curl -sf http://localhost:9000/minio/health/live > /dev/null 2>&1; do
+        attempt=$((attempt + 1))
+        if [ $attempt -ge $max_attempts ]; then
+            log_error "MinIO failed to start"
+            return 1
+        fi
+        sleep 1
+    done
+
+    log_success "MinIO started"
+
+    # Configure MinIO
+    configure_minio
+}
+
+# Configure MinIO
+configure_minio() {
+    log_info "Configuring MinIO..."
+
+    local MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-minioadmin}"
+    local MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-minioadmin}"
+
+    # Set up mc alias
+    mc alias set local http://localhost:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" > /dev/null 2>&1 || true
+
+    # Create buckets
+    mc mb local/original --ignore-existing > /dev/null 2>&1 || true
+    mc mb local/processed --ignore-existing > /dev/null 2>&1 || true
+
+    log_success "MinIO configured (buckets: original, processed)"
+}
+
+# Build services
+build_services() {
+    log_info "Building services..."
+
+    cd "$PROJECT_ROOT"
+
+    # Build all services
+    if [[ -f "$PROJECT_ROOT/Makefile" ]]; then
+        make build
+    else
+        # Manual build
+        cd "$PROJECT_ROOT/services/gateway" && go build -o "$PROJECT_ROOT/bin/gateway" cmd/main.go
+        cd "$PROJECT_ROOT/services/analyzer" && go build -o "$PROJECT_ROOT/bin/analyzer" cmd/main.go
+        cd "$PROJECT_ROOT/services/processor" && go build -o "$PROJECT_ROOT/bin/processor" cmd/main.go
+    fi
+
+    log_success "Services built"
+}
+
+# Start Gateway service
+start_gateway() {
+    log_info "Starting Gateway service..."
+
+    export RABBITMQ_URL="${RABBITMQ_URL:-amqp://user:password@localhost:5672/}"
+    export MINIO_ENDPOINT="${MINIO_ENDPOINT:-localhost:9000}"
+    export MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-minioadmin}"
+    export MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-minioadmin}"
+    export MINIO_USE_SSL="${MINIO_USE_SSL:-false}"
+    export SERVER_PORT="${SERVER_PORT:-8080}"
+    export LOG_LEVEL="${LOG_LEVEL:-info}"
+    export LOG_FORMAT="${LOG_FORMAT:-text}"
+
+    "$PROJECT_ROOT/bin/gateway" > "$LOG_DIR/gateway.log" 2>&1 &
+    echo $! > "$PID_DIR/gateway.pid"
+
+    log_success "Gateway started (PID: $(cat $PID_DIR/gateway.pid))"
+}
+
+# Start Analyzer service
+start_analyzer() {
+    log_info "Starting Analyzer service..."
+
+    export RABBITMQ_URL="${RABBITMQ_URL:-amqp://user:password@localhost:5672/}"
+    export RABBITMQ_CONSUMER_QUEUE="${RABBITMQ_CONSUMER_QUEUE:-image_upload}"
+    export RABBITMQ_PUBLISHER_QUEUE="${RABBITMQ_PUBLISHER_QUEUE:-metadata_generated}"
+    export MINIO_ENDPOINT="${MINIO_ENDPOINT:-localhost:9000}"
+    export MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-minioadmin}"
+    export MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-minioadmin}"
+    export MINIO_USE_SSL="${MINIO_USE_SSL:-false}"
+    export MINIO_ORIGINAL_BUCKET="${MINIO_ORIGINAL_BUCKET:-original}"
+    export OPENROUTER_API_KEY="${OPENROUTER_API_KEY:-}"
+    export OPENROUTER_MODEL="${OPENROUTER_MODEL:-openai/gpt-4o}"
+    export WORKER_CONCURRENCY="${WORKER_CONCURRENCY:-3}"
+    export LOG_LEVEL="${LOG_LEVEL:-info}"
+    export LOG_FORMAT="${LOG_FORMAT:-text}"
+
+    if [[ -z "$OPENROUTER_API_KEY" ]]; then
+        log_error "OPENROUTER_API_KEY is not set in $CONFIG_FILE"
+        log_error "Analyzer will not start without API key"
+        return 1
+    fi
+
+    "$PROJECT_ROOT/bin/analyzer" > "$LOG_DIR/analyzer.log" 2>&1 &
+    echo $! > "$PID_DIR/analyzer.pid"
+
+    log_success "Analyzer started (PID: $(cat $PID_DIR/analyzer.pid))"
+}
+
+# Start Processor service
+start_processor() {
+    log_info "Starting Processor service..."
+
+    export RABBITMQ_URL="${RABBITMQ_URL:-amqp://user:password@localhost:5672/}"
+    export RABBITMQ_CONSUMER_QUEUE="${RABBITMQ_CONSUMER_QUEUE:-metadata_generated}"
+    export RABBITMQ_PUBLISHER_QUEUE="${RABBITMQ_PUBLISHER_QUEUE:-image_processed}"
+    export MINIO_ENDPOINT="${MINIO_ENDPOINT:-localhost:9000}"
+    export MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-minioadmin}"
+    export MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-minioadmin}"
+    export MINIO_USE_SSL="${MINIO_USE_SSL:-false}"
+    export MINIO_ORIGINAL_BUCKET="${MINIO_ORIGINAL_BUCKET:-original}"
+    export MINIO_PROCESSED_BUCKET="${MINIO_PROCESSED_BUCKET:-processed}"
+    export EXIFTOOL_BINARY_PATH="${EXIFTOOL_BINARY_PATH:-$(which exiftool)}"
+    export EXIFTOOL_TEMP_DIR="${EXIFTOOL_TEMP_DIR:-$HOME/photo-tags/tmp/processor}"
+    export WORKER_CONCURRENCY="${WORKER_CONCURRENCY:-3}"
+    export LOG_LEVEL="${LOG_LEVEL:-info}"
+    export LOG_FORMAT="${LOG_FORMAT:-text}"
+
+    "$PROJECT_ROOT/bin/processor" > "$LOG_DIR/processor.log" 2>&1 &
+    echo $! > "$PID_DIR/processor.pid"
+
+    log_success "Processor started (PID: $(cat $PID_DIR/processor.pid))"
+}
+
+# Stop all services
+stop_all() {
+    log_info "Stopping all services..."
+
+    # Stop application services
+    for service in gateway analyzer processor; do
+        if [[ -f "$PID_DIR/$service.pid" ]]; then
+            local pid=$(cat "$PID_DIR/$service.pid")
+            if kill -0 "$pid" 2>/dev/null; then
+                log_info "Stopping $service (PID: $pid)..."
+                kill "$pid"
+                rm "$PID_DIR/$service.pid"
+            fi
+        fi
+    done
+
+    # Stop MinIO
+    if [[ -f "$PID_DIR/minio.pid" ]]; then
+        local pid=$(cat "$PID_DIR/minio.pid")
+        if kill -0 "$pid" 2>/dev/null; then
+            log_info "Stopping MinIO..."
+            kill "$pid"
+            rm "$PID_DIR/minio.pid"
+        fi
+    elif command_exists systemctl && systemctl list-unit-files | grep -q minio.service; then
+        sudo systemctl stop minio
+    fi
+
+    # Stop RabbitMQ
+    if [[ "$OS" == "darwin" ]]; then
+        brew services stop rabbitmq
+    elif command_exists systemctl; then
+        sudo systemctl stop rabbitmq-server
+    else
+        rabbitmqctl stop
+    fi
+
+    log_success "All services stopped"
+}
+
+# Show status
+show_status() {
+    log_info "Service Status:"
+    echo ""
+
+    # Check RabbitMQ
+    if pgrep -f rabbitmq-server > /dev/null; then
+        echo -e "  ${GREEN}●${NC} RabbitMQ       - running"
+    else
+        echo -e "  ${RED}●${NC} RabbitMQ       - stopped"
+    fi
+
+    # Check MinIO
+    if pgrep -f "minio server" > /dev/null; then
+        echo -e "  ${GREEN}●${NC} MinIO          - running"
+    else
+        echo -e "  ${RED}●${NC} MinIO          - stopped"
+    fi
+
+    # Check application services
+    for service in gateway analyzer processor; do
+        if [[ -f "$PID_DIR/$service.pid" ]]; then
+            local pid=$(cat "$PID_DIR/$service.pid")
+            if kill -0 "$pid" 2>/dev/null; then
+                echo -e "  ${GREEN}●${NC} $(printf '%-14s' $service) - running (PID: $pid)"
+            else
+                echo -e "  ${RED}●${NC} $(printf '%-14s' $service) - stopped (stale PID file)"
+                rm "$PID_DIR/$service.pid"
+            fi
+        else
+            echo -e "  ${RED}●${NC} $(printf '%-14s' $service) - stopped"
+        fi
+    done
+
+    echo ""
+    log_info "Service URLs:"
+    echo "  Gateway:          http://localhost:8080"
+    echo "  RabbitMQ UI:      http://localhost:15672 (user/password)"
+    echo "  MinIO Console:    http://localhost:9001 (minioadmin/minioadmin)"
+    echo ""
+    log_info "Logs directory: $LOG_DIR"
+}
+
+# Tail logs
+tail_logs() {
+    log_info "Tailing all service logs... (Ctrl+C to exit)"
+    echo ""
+
+    tail -f "$LOG_DIR"/*.log 2>/dev/null || {
+        log_warn "No log files found"
+        exit 1
+    }
+}
+
+# Main function
+main() {
+    case "${1:-start}" in
+        start)
+            log_info "Starting photo-tags services locally..."
+            echo ""
+
+            create_directories
+            load_config
+
+            start_rabbitmq
+            echo ""
+
+            start_minio
+            echo ""
+
+            # Check if binaries exist, build if not
+            if [[ ! -f "$PROJECT_ROOT/bin/gateway" ]] || \
+               [[ ! -f "$PROJECT_ROOT/bin/analyzer" ]] || \
+               [[ ! -f "$PROJECT_ROOT/bin/processor" ]]; then
+                build_services
+                echo ""
+            fi
+
+            start_gateway
+            sleep 2
+
+            start_analyzer
+            sleep 2
+
+            start_processor
+            echo ""
+
+            log_success "All services started!"
+            echo ""
+            show_status
+            ;;
+
+        stop)
+            stop_all
+            ;;
+
+        restart)
+            stop_all
+            echo ""
+            sleep 2
+            main start
+            ;;
+
+        status)
+            show_status
+            ;;
+
+        logs)
+            tail_logs
+            ;;
+
+        build)
+            build_services
+            ;;
+
+        *)
+            echo "Usage: $0 {start|stop|restart|status|logs|build}"
+            echo ""
+            echo "Commands:"
+            echo "  start    - Start all services"
+            echo "  stop     - Stop all services"
+            echo "  restart  - Restart all services"
+            echo "  status   - Show service status"
+            echo "  logs     - Tail all service logs"
+            echo "  build    - Build all services"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
Add comprehensive support for local deployment without Docker on macOS and Linux ARM64/x86_64. This is particularly useful for Raspberry Pi and resource-constrained devices.

Features:
- install-local.sh: Automated installation of all dependencies (Go, ExifTool, RabbitMQ, MinIO)
- run-local.sh: Service management script with start/stop/restart/status/logs commands
- LOCAL_DEPLOYMENT.md: Detailed documentation with platform-specific instructions
- .env.local.example: Configuration template for local deployment
- Makefile targets: make local-start, local-stop, local-status, etc.

Platform Support:
- macOS (Intel and Apple Silicon M1/M2/M3)
- Linux Ubuntu/Debian (x86_64 and ARM64)
- Raspberry Pi 3/4 (ARM64)

Benefits:
- Better performance on ARM devices
- Lower memory footprint
- Direct access to system resources
- Supports both Docker and native deployment options