### PR TITLE
Create File Watcher Service for image processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The project is built using a microservice architecture and includes the followin
 -   **Gateway Service** - receives images and sends results via Telegram API
 -   **Analyzer Service** - generates metadata using free vision models from OpenRouter with automatic model selection
 -   **Processor Service** - writes metadata to images
+-   **File Watcher Service** - monitors directories for batch image processing without Telegram
 -   **RabbitMQ** - message exchange between services
 -   **MinIO** - image storage
 
@@ -98,6 +99,32 @@ The service handles all technical complexities (model selection, rate limits, re
 -   **Title** - brief description of the image
 -   **Description** - more detailed description up to 200 characters
 -   **Keywords** - 49 keywords describing the image
+
+### File Watcher Service - Batch Processing
+
+In addition to the Telegram bot interface, you can process images in batch mode using the File Watcher Service:
+
+1. **Copy images to input directory**:
+```bash
+docker cp /path/to/images/* filewatcher:/app/input/
+```
+
+2. **Monitor processing**:
+```bash
+curl http://localhost:8081/stats
+```
+
+3. **Retrieve processed images**:
+```bash
+docker cp filewatcher:/app/output/. /path/to/output/
+```
+
+4. **Trigger manual scan**:
+```bash
+curl -X POST http://localhost:8081/scan
+```
+
+For more details, see [File Watcher Service README](services/filewatcher/README.md).
 
 ## Monitoring
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -38,3 +38,11 @@ LOG_FORMAT=json
 DD_API_KEY=
 DD_SITE=datadoghq.com
 DD_ENV=development
+
+# File Watcher Service configuration
+INPUT_DIR=/app/input
+OUTPUT_DIR=/app/output
+PROCESSED_DIR=/app/input/processed
+SCAN_INTERVAL_SECONDS=5
+USE_FSNOTIFY=true
+MAX_FILE_SIZE_MB=50

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -105,6 +105,37 @@ services:
         volumes:
             - processor_temp:/tmp/processor
 
+    filewatcher:
+        container_name: filewatcher
+        build:
+            context: ..
+            dockerfile: docker/Dockerfile.service
+            args:
+                SERVICE: filewatcher
+        ports:
+            - '8081:8081'
+        depends_on:
+            rabbitmq:
+                condition: service_healthy
+            minio:
+                condition: service_healthy
+        environment:
+            - RABBITMQ_URL=amqp://user:password@rabbitmq:5672/
+            - MINIO_ENDPOINT=minio:9000
+            - MINIO_ACCESS_KEY=minioadmin
+            - MINIO_SECRET_KEY=minioadmin
+            - INPUT_DIR=/app/input
+            - OUTPUT_DIR=/app/output
+            - PROCESSED_DIR=/app/input/processed
+            - SCAN_INTERVAL_SECONDS=5
+            - USE_FSNOTIFY=true
+            - MAX_FILE_SIZE_MB=50
+            - SERVER_PORT=8081
+        restart: unless-stopped
+        volumes:
+            - filewatcher_input:/app/input
+            - filewatcher_output:/app/output
+
     datadog:
         container_name: datadog-agent
         image: gcr.io/datadoghq/agent:7
@@ -132,3 +163,5 @@ volumes:
     rabbitmq_data:
     minio_data:
     processor_temp:
+    filewatcher_input:
+    filewatcher_output:

--- a/services/filewatcher/README.md
+++ b/services/filewatcher/README.md
@@ -1,0 +1,253 @@
+# File Watcher Service
+
+File Watcher Service monitors input directories for new images, processes them through the photo-tags pipeline, and saves the results to an output directory. This enables batch processing of images without using the Telegram bot interface.
+
+## Features
+
+- **Automated File Monitoring**: Uses fsnotify or polling to detect new images
+- **Batch Processing**: Process all files in input directory at once
+- **File Validation**: Validates image format (JPG, JPEG, PNG) and file size
+- **MinIO Integration**: Uploads images to MinIO storage
+- **RabbitMQ Integration**: Publishes messages to processing queue and consumes results
+- **REST API**: HTTP endpoints for manual scanning and statistics
+- **Statistics Tracking**: Tracks files processed, success/failure rates, and errors
+- **Graceful Shutdown**: Handles SIGINT/SIGTERM signals properly
+- **Metadata Export**: Saves processing metadata as JSON files alongside images
+
+## Architecture
+
+```
+┌─────────────┐
+│   Input     │
+│  Directory  │
+└──────┬──────┘
+       │
+       v
+┌─────────────┐     ┌──────────┐     ┌──────────────┐
+│   Watcher   │────>│  MinIO   │────>│   RabbitMQ   │
+│  (fsnotify) │     │ (upload) │     │ (image_upload)│
+└─────────────┘     └──────────┘     └──────────────┘
+                                             │
+                                             v
+                                      ┌──────────────┐
+                                      │   Analyzer   │
+                                      │   Service    │
+                                      └──────┬───────┘
+                                             │
+                                             v
+                                      ┌──────────────┐
+                                      │  Processor   │
+                                      │   Service    │
+                                      └──────┬───────┘
+                                             │
+       ┌─────────────────────────────────────┘
+       │
+       v
+┌─────────────┐     ┌──────────┐     ┌──────────────┐
+│  Consumer   │<────│  MinIO   │<────│   RabbitMQ   │
+│             │     │(download)│     │(image_processed)│
+└──────┬──────┘     └──────────┘     └──────────────┘
+       │
+       v
+┌─────────────┐
+│   Output    │
+│  Directory  │
+└─────────────┘
+```
+
+## Configuration
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `INPUT_DIR` | `/app/input` | Directory to watch for new images |
+| `OUTPUT_DIR` | `/app/output` | Directory to save processed images |
+| `PROCESSED_DIR` | `/app/input/processed` | Directory to move processed files |
+| `SCAN_INTERVAL_SECONDS` | `5` | Polling interval in seconds (if fsnotify disabled) |
+| `USE_FSNOTIFY` | `true` | Use fsnotify for file system events |
+| `MAX_FILE_SIZE_MB` | `50` | Maximum file size in megabytes |
+| `SERVER_PORT` | `8081` | HTTP API server port |
+| `RABBITMQ_URL` | `amqp://user:password@localhost:5672/` | RabbitMQ connection URL |
+| `MINIO_ENDPOINT` | `localhost:9000` | MinIO server endpoint |
+| `MINIO_ACCESS_KEY` | `minioadmin` | MinIO access key |
+| `MINIO_SECRET_KEY` | `minioadmin` | MinIO secret key |
+| `MINIO_USE_SSL` | `false` | Use SSL for MinIO connection |
+
+## API Endpoints
+
+### Health Check
+```bash
+GET /health
+```
+
+Response:
+```json
+{
+  "status": "healthy",
+  "service": "filewatcher",
+  "time": "2025-01-15T10:30:00Z"
+}
+```
+
+### Statistics
+```bash
+GET /stats
+```
+
+Response:
+```json
+{
+  "files_processed": 42,
+  "files_successful": 40,
+  "files_failed": 2,
+  "files_received": 38,
+  "last_processed_time": "2025-01-15T10:29:45Z",
+  "start_time": "2025-01-15T09:00:00Z",
+  "recent_errors": [
+    {
+      "timestamp": "2025-01-15T10:15:30Z",
+      "message": "File too large: 52428800 bytes (max: 52428800 bytes)",
+      "trace_id": "abc123-def456"
+    }
+  ]
+}
+```
+
+### Manual Scan
+```bash
+POST /scan
+```
+
+Response:
+```json
+{
+  "status": "started",
+  "message": "Manual scan initiated",
+  "time": "2025-01-15T10:30:00Z"
+}
+```
+
+## Usage
+
+### Using Docker Compose
+
+1. **Start the service**:
+```bash
+cd docker
+docker-compose up -d filewatcher
+```
+
+2. **Add images to input directory**:
+```bash
+# Copy images to the input volume
+docker cp image.jpg filewatcher:/app/input/
+```
+
+3. **Check statistics**:
+```bash
+curl http://localhost:8081/stats
+```
+
+4. **Trigger manual scan**:
+```bash
+curl -X POST http://localhost:8081/scan
+```
+
+5. **Get processed images**:
+```bash
+# Copy from output volume
+docker cp filewatcher:/app/output/image.jpg ./
+```
+
+### Using Local Directories
+
+You can also mount local directories as volumes:
+
+```yaml
+volumes:
+  - ./data/input:/app/input
+  - ./data/output:/app/output
+```
+
+Then simply drop images into `./data/input` and find processed results in `./data/output`.
+
+## File Processing Flow
+
+1. **Detection**: File watcher detects new image in input directory
+2. **Validation**: Checks file extension and size
+3. **Upload**: Uploads to MinIO `original` bucket
+4. **Queue**: Publishes `ImageUpload` message to RabbitMQ
+5. **Processing**: Analyzer generates metadata, Processor embeds it
+6. **Download**: Consumer receives `ImageProcessed` message
+7. **Save**: Downloads from MinIO `processed` bucket and saves to output directory
+8. **Metadata**: Creates `.json` file with processing metadata
+9. **Cleanup**: Moves original file to processed directory
+
+## Logging
+
+All operations are logged in JSON format with trace IDs for correlation:
+
+```json
+{
+  "level": "info",
+  "service": "filewatcher",
+  "message": "Processing file",
+  "trace_id": "abc123-def456",
+  "file": "/app/input/image.jpg"
+}
+```
+
+## Development
+
+### Building Locally
+
+```bash
+cd services/filewatcher
+go mod download
+go build -o bin/filewatcher cmd/main.go
+```
+
+### Running Tests
+
+```bash
+go test ./...
+```
+
+### Running Locally
+
+```bash
+export INPUT_DIR=./data/input
+export OUTPUT_DIR=./data/output
+export PROCESSED_DIR=./data/processed
+export RABBITMQ_URL=amqp://user:password@localhost:5672/
+export MINIO_ENDPOINT=localhost:9000
+
+./bin/filewatcher
+```
+
+## Troubleshooting
+
+### Files not being processed
+
+1. Check file permissions on input directory
+2. Verify file extension is supported (jpg, jpeg, png)
+3. Check file size is under MAX_FILE_SIZE_MB
+4. Review logs: `docker logs filewatcher`
+
+### Output directory empty
+
+1. Check RabbitMQ connection
+2. Verify Analyzer and Processor services are running
+3. Check statistics for errors: `curl http://localhost:8081/stats`
+4. Review consumer logs for download errors
+
+### High memory usage
+
+1. Reduce SCAN_INTERVAL_SECONDS for less frequent scanning
+2. Process smaller batches of files
+3. Increase MAX_FILE_SIZE_MB limit to filter out large files
+
+## License
+
+This service is part of the photo-tags project.

--- a/services/filewatcher/cmd/main.go
+++ b/services/filewatcher/cmd/main.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/shabohin/photo-tags/pkg/logging"
+	"github.com/shabohin/photo-tags/pkg/messaging"
+	"github.com/shabohin/photo-tags/pkg/storage"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/api"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/config"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/consumer"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/processor"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/statistics"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/watcher"
+)
+
+func retry(attempts int, delay time.Duration, logger *logging.Logger, operationName string, fn func() error) error {
+	for i := 1; i <= attempts; i++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		logger.Error(fmt.Sprintf("Attempt %d/%d failed for %s", i, attempts, operationName), err)
+		if i < attempts {
+			time.Sleep(delay)
+		}
+	}
+	return fmt.Errorf("all %d attempts failed for %s", attempts, operationName)
+}
+
+func main() {
+	fmt.Println("Starting File Watcher Service...")
+	log.Println("File Watcher Service is up and running")
+
+	// Create context that will be canceled on SIGINT or SIGTERM
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Handle signals
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-signals
+		log.Printf("Received signal: %v", sig)
+		cancel()
+	}()
+
+	// Load configuration
+	cfg := config.LoadConfig()
+
+	// Create logger
+	logger := logging.NewLogger("filewatcher")
+	logger.Info("Starting File Watcher Service v1.0.0 at "+time.Now().Format(time.RFC3339), nil)
+
+	// Initialize statistics
+	stats := statistics.NewStatistics()
+
+	// Initialize dependencies
+	minioClient, rabbitmqClient, err := initializeDependencies(ctx, cfg, logger)
+	if err != nil {
+		logger.Error("Failed to initialize dependencies", err)
+		os.Exit(1)
+	}
+	defer rabbitmqClient.Close()
+
+	// Create processor
+	proc := processor.NewProcessor(cfg, logger, minioClient, rabbitmqClient, stats)
+
+	// Create watcher
+	watch := watcher.NewWatcher(cfg, logger, proc)
+
+	// Create consumer
+	cons := consumer.NewConsumer(cfg, logger, minioClient, rabbitmqClient, stats)
+
+	// Create API server
+	apiServer := api.NewServer(cfg, logger, watch, stats)
+
+	// Start consumer
+	if err := cons.Start(ctx); err != nil {
+		logger.Error("Failed to start consumer", err)
+		os.Exit(1)
+	}
+	logger.Info("Consumer started", map[string]interface{}{
+		"queue": messaging.QueueImageProcessed,
+	})
+
+	// Start watcher
+	go func() {
+		if err := watch.Start(ctx); err != nil {
+			logger.Error("Watcher error", err)
+		}
+	}()
+	logger.Info("File watcher started", map[string]interface{}{
+		"input_dir":     cfg.InputDir,
+		"output_dir":    cfg.OutputDir,
+		"use_fsnotify":  cfg.UseFsnotify,
+		"scan_interval": cfg.ScanInterval,
+	})
+
+	// Start API server
+	go func() {
+		if err := apiServer.Start(ctx); err != nil {
+			logger.Error("API server error", err)
+		}
+	}()
+	logger.Info("API server started", map[string]interface{}{
+		"port": cfg.ServerPort,
+	})
+
+	// Block until context is canceled
+	logger.Info("File Watcher Service running. Press Ctrl+C to stop.", nil)
+	<-ctx.Done()
+	logger.Info("Shutting down File Watcher Service", nil)
+
+	// Allow some time for graceful shutdown
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+
+	select {
+	case <-shutdownCtx.Done():
+		logger.Info("Shutdown timed out, forcing exit", nil)
+	case <-time.After(2 * time.Second):
+		logger.Info("File Watcher Service shutdown complete", nil)
+	}
+}
+
+// initializeDependencies initializes MinIO and RabbitMQ clients
+func initializeDependencies(
+	ctx context.Context,
+	cfg *config.Config,
+	logger *logging.Logger,
+) (storage.MinIOInterface, messaging.RabbitMQInterface, error) {
+	var minioClient storage.MinIOInterface
+	var rabbitmqClient messaging.RabbitMQInterface
+
+	logger.Info("Initializing MinIO client", map[string]interface{}{
+		"endpoint": cfg.MinIOEndpoint,
+		"use_ssl":  cfg.MinIOUseSSL,
+	})
+
+	err := retry(5, 2*time.Second, logger, "MinIO client creation", func() error {
+		client, clientErr := storage.NewMinIOClient(
+			cfg.MinIOEndpoint, cfg.MinIOAccessKey, cfg.MinIOSecretKey, cfg.MinIOUseSSL)
+		if clientErr != nil {
+			return clientErr
+		}
+		minioClient = client
+		return nil
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create MinIO client after retries: %w", err)
+	}
+
+	// Ensure buckets exist
+	err = retry(5, 2*time.Second, logger, "MinIO bucket check (original)", func() error {
+		return minioClient.EnsureBucketExists(ctx, storage.BucketOriginal)
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to ensure original bucket exists: %w", err)
+	}
+
+	err = retry(5, 2*time.Second, logger, "MinIO bucket check (processed)", func() error {
+		return minioClient.EnsureBucketExists(ctx, storage.BucketProcessed)
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to ensure processed bucket exists: %w", err)
+	}
+
+	logger.Info("Initializing RabbitMQ client", map[string]interface{}{
+		"url": cfg.RabbitMQURL,
+	})
+
+	err = retry(5, 2*time.Second, logger, "RabbitMQ client creation", func() error {
+		client, clientErr := messaging.NewRabbitMQClient(cfg.RabbitMQURL)
+		if clientErr != nil {
+			return clientErr
+		}
+		rabbitmqClient = client
+		return nil
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create RabbitMQ client after retries: %w", err)
+	}
+
+	logger.Info("Declaring RabbitMQ queues", nil)
+
+	if _, err := rabbitmqClient.DeclareQueue(messaging.QueueImageUpload); err != nil {
+		return nil, nil, fmt.Errorf("failed to declare queue %s: %w", messaging.QueueImageUpload, err)
+	}
+
+	if _, err := rabbitmqClient.DeclareQueue(messaging.QueueImageProcessed); err != nil {
+		return nil, nil, fmt.Errorf("failed to declare queue %s: %w", messaging.QueueImageProcessed, err)
+	}
+
+	logger.Info("Dependencies initialized successfully", nil)
+	return minioClient, rabbitmqClient, nil
+}

--- a/services/filewatcher/go.mod
+++ b/services/filewatcher/go.mod
@@ -1,0 +1,29 @@
+module github.com/shabohin/photo-tags/services/filewatcher
+
+go 1.24.0
+
+require (
+	github.com/fsnotify/fsnotify v1.8.0
+	github.com/google/uuid v1.6.0
+	github.com/minio/minio-go/v7 v7.0.87
+	github.com/shabohin/photo-tags/pkg v0.0.0
+)
+
+require (
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/go-ini/ini v1.67.0 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/klauspost/compress v1.17.11 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
+	github.com/minio/crc64nvme v1.0.1 // indirect
+	github.com/minio/md5-simd v1.1.2 // indirect
+	github.com/rs/xid v1.6.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/streadway/amqp v1.1.0 // indirect
+	golang.org/x/crypto v0.33.0 // indirect
+	golang.org/x/net v0.35.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+	golang.org/x/text v0.22.0 // indirect
+)
+
+replace github.com/shabohin/photo-tags/pkg => ../../pkg

--- a/services/filewatcher/internal/api/api.go
+++ b/services/filewatcher/internal/api/api.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/shabohin/photo-tags/pkg/logging"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/config"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/statistics"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/watcher"
+)
+
+// Server represents the HTTP API server
+type Server struct {
+	cfg     *config.Config
+	logger  *logging.Logger
+	watcher *watcher.Watcher
+	stats   *statistics.Statistics
+	server  *http.Server
+}
+
+// NewServer creates a new API server
+func NewServer(
+	cfg *config.Config,
+	logger *logging.Logger,
+	watcher *watcher.Watcher,
+	stats *statistics.Statistics,
+) *Server {
+	return &Server{
+		cfg:     cfg,
+		logger:  logger,
+		watcher: watcher,
+		stats:   stats,
+	}
+}
+
+// Start starts the HTTP server
+func (s *Server) Start(ctx context.Context) error {
+	mux := http.NewServeMux()
+
+	// Register endpoints
+	mux.HandleFunc("/health", s.handleHealth)
+	mux.HandleFunc("/stats", s.handleStats)
+	mux.HandleFunc("/scan", s.handleScan)
+
+	s.server = &http.Server{
+		Addr:    fmt.Sprintf(":%d", s.cfg.ServerPort),
+		Handler: s.loggingMiddleware(mux),
+	}
+
+	s.logger.Info("Starting HTTP server", map[string]interface{}{
+		"port": s.cfg.ServerPort,
+	})
+
+	// Start server in a goroutine
+	errChan := make(chan error, 1)
+	go func() {
+		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errChan <- err
+		}
+	}()
+
+	// Wait for context cancellation or error
+	select {
+	case <-ctx.Done():
+		s.logger.Info("Shutting down HTTP server", nil)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return s.server.Shutdown(shutdownCtx)
+	case err := <-errChan:
+		return err
+	}
+}
+
+// handleHealth handles health check requests
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	response := map[string]interface{}{
+		"status":  "healthy",
+		"service": "filewatcher",
+		"time":    time.Now().Format(time.RFC3339),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+// handleStats handles statistics requests
+func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	stats := s.stats.GetSnapshot()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(stats)
+}
+
+// handleScan handles manual scan trigger requests
+func (s *Server) handleScan(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.logger.Info("Manual scan triggered via API", nil)
+
+	// Trigger scan in background
+	go func() {
+		ctx := context.Background()
+		if err := s.watcher.TriggerManualScan(ctx); err != nil {
+			s.logger.Error("Manual scan failed", err)
+		}
+	}()
+
+	response := map[string]interface{}{
+		"status":  "started",
+		"message": "Manual scan initiated",
+		"time":    time.Now().Format(time.RFC3339),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	json.NewEncoder(w).Encode(response)
+}
+
+// loggingMiddleware logs all HTTP requests
+func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		// Log request
+		s.logger.Info("HTTP request", map[string]interface{}{
+			"method": r.Method,
+			"path":   r.URL.Path,
+			"remote": r.RemoteAddr,
+		})
+
+		// Call next handler
+		next.ServeHTTP(w, r)
+
+		// Log response
+		s.logger.Info("HTTP response", map[string]interface{}{
+			"method":   r.Method,
+			"path":     r.URL.Path,
+			"duration": time.Since(start).String(),
+		})
+	})
+}

--- a/services/filewatcher/internal/config/config.go
+++ b/services/filewatcher/internal/config/config.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+// Config holds all configuration for the filewatcher service
+type Config struct {
+	// Input/Output directories
+	InputDir     string
+	OutputDir    string
+	ProcessedDir string
+
+	// Scan configuration
+	ScanInterval time.Duration
+	UseFsnotify  bool
+
+	// File validation
+	MaxFileSizeMB     int64
+	AllowedExtensions []string
+
+	// RabbitMQ configuration
+	RabbitMQURL string
+
+	// MinIO configuration
+	MinIOEndpoint  string
+	MinIOAccessKey string
+	MinIOSecretKey string
+	MinIOUseSSL    bool
+
+	// Server configuration
+	ServerPort int
+}
+
+// LoadConfig loads configuration from environment variables
+func LoadConfig() *Config {
+	cfg := &Config{
+		InputDir:          getEnv("INPUT_DIR", "/app/input"),
+		OutputDir:         getEnv("OUTPUT_DIR", "/app/output"),
+		ProcessedDir:      getEnv("PROCESSED_DIR", "/app/input/processed"),
+		ScanInterval:      time.Duration(getEnvInt("SCAN_INTERVAL_SECONDS", 5)) * time.Second,
+		UseFsnotify:       getEnvBool("USE_FSNOTIFY", true),
+		MaxFileSizeMB:     int64(getEnvInt("MAX_FILE_SIZE_MB", 50)),
+		AllowedExtensions: []string{".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG"},
+		RabbitMQURL:       getEnv("RABBITMQ_URL", "amqp://user:password@localhost:5672/"),
+		MinIOEndpoint:     getEnv("MINIO_ENDPOINT", "localhost:9000"),
+		MinIOAccessKey:    getEnv("MINIO_ACCESS_KEY", "minioadmin"),
+		MinIOSecretKey:    getEnv("MINIO_SECRET_KEY", "minioadmin"),
+		MinIOUseSSL:       getEnvBool("MINIO_USE_SSL", false),
+		ServerPort:        getEnvInt("SERVER_PORT", 8081),
+	}
+
+	return cfg
+}
+
+// Helper functions to get environment variables
+func getEnv(key, defaultValue string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultValue
+}
+
+func getEnvBool(key string, defaultValue bool) bool {
+	if value, exists := os.LookupEnv(key); exists {
+		boolValue, err := strconv.ParseBool(value)
+		if err == nil {
+			return boolValue
+		}
+	}
+	return defaultValue
+}
+
+func getEnvInt(key string, defaultValue int) int {
+	if value, exists := os.LookupEnv(key); exists {
+		intValue, err := strconv.Atoi(value)
+		if err == nil {
+			return intValue
+		}
+	}
+	return defaultValue
+}

--- a/services/filewatcher/internal/consumer/consumer.go
+++ b/services/filewatcher/internal/consumer/consumer.go
@@ -1,0 +1,150 @@
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/shabohin/photo-tags/pkg/logging"
+	"github.com/shabohin/photo-tags/pkg/messaging"
+	"github.com/shabohin/photo-tags/pkg/models"
+	"github.com/shabohin/photo-tags/pkg/storage"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/config"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/statistics"
+)
+
+// Consumer handles consuming messages from RabbitMQ
+type Consumer struct {
+	cfg      *config.Config
+	logger   *logging.Logger
+	minio    storage.MinIOInterface
+	rabbitmq messaging.RabbitMQInterface
+	stats    *statistics.Statistics
+}
+
+// NewConsumer creates a new Consumer instance
+func NewConsumer(
+	cfg *config.Config,
+	logger *logging.Logger,
+	minio storage.MinIOInterface,
+	rabbitmq messaging.RabbitMQInterface,
+	stats *statistics.Statistics,
+) *Consumer {
+	return &Consumer{
+		cfg:      cfg,
+		logger:   logger,
+		minio:    minio,
+		rabbitmq: rabbitmq,
+		stats:    stats,
+	}
+}
+
+// Start starts consuming messages from RabbitMQ
+func (c *Consumer) Start(ctx context.Context) error {
+	c.logger.Info("Starting consumer", map[string]interface{}{
+		"queue": messaging.QueueImageProcessed,
+	})
+
+	// Consume messages from image_processed queue
+	return c.rabbitmq.ConsumeMessages(messaging.QueueImageProcessed, func(body []byte) error {
+		return c.handleMessage(ctx, body)
+	})
+}
+
+// handleMessage handles a single message from RabbitMQ
+func (c *Consumer) handleMessage(ctx context.Context, body []byte) error {
+	var msg models.ImageProcessed
+	if err := json.Unmarshal(body, &msg); err != nil {
+		c.logger.Error("Failed to unmarshal message", err)
+		return err
+	}
+
+	c.logger.Info("Received processed image", map[string]interface{}{
+		"trace_id": msg.TraceID,
+		"status":   msg.Status,
+	})
+
+	c.stats.IncrementReceived()
+
+	// Only process images from filewatcher
+	if msg.GroupID != "filewatcher" {
+		c.logger.Info("Skipping message from different group", map[string]interface{}{
+			"trace_id": msg.TraceID,
+			"group_id": msg.GroupID,
+		})
+		return nil
+	}
+
+	// Check status
+	if msg.Status != "success" {
+		c.logger.Error("Image processing failed", fmt.Errorf("%s", msg.Error))
+		c.stats.AddError(fmt.Sprintf("Processing failed: %s", msg.Error), msg.TraceID)
+		return nil // Don't requeue, just log the error
+	}
+
+	// Download processed image from MinIO
+	fileData, err := c.minio.DownloadFile(ctx, storage.BucketProcessed, msg.ProcessedPath)
+	if err != nil {
+		c.logger.Error("Failed to download from MinIO", err)
+		c.stats.AddError(fmt.Sprintf("Failed to download: %v", err), msg.TraceID)
+		return err
+	}
+
+	// Ensure output directory exists
+	if err := os.MkdirAll(c.cfg.OutputDir, 0755); err != nil {
+		c.logger.Error("Failed to create output directory", err)
+		c.stats.AddError(fmt.Sprintf("Failed to create output dir: %v", err), msg.TraceID)
+		return err
+	}
+
+	// Save to output directory
+	outputPath := filepath.Join(c.cfg.OutputDir, msg.OriginalFilename)
+	if err := os.WriteFile(outputPath, fileData, 0644); err != nil {
+		c.logger.Error("Failed to write file", err)
+		c.stats.AddError(fmt.Sprintf("Failed to write file: %v", err), msg.TraceID)
+		return err
+	}
+
+	c.logger.Info("Saved processed image", map[string]interface{}{
+		"trace_id":    msg.TraceID,
+		"output_path": outputPath,
+	})
+
+	// Save metadata JSON if available
+	if err := c.saveMetadata(msg, outputPath); err != nil {
+		c.logger.Error("Failed to save metadata", err)
+		// Don't fail the entire operation
+	}
+
+	return nil
+}
+
+// saveMetadata saves metadata to a JSON file next to the image
+func (c *Consumer) saveMetadata(msg models.ImageProcessed, imagePath string) error {
+	metadata := map[string]interface{}{
+		"trace_id":          msg.TraceID,
+		"original_filename": msg.OriginalFilename,
+		"processed_path":    msg.ProcessedPath,
+		"timestamp":         msg.Timestamp,
+		"status":            msg.Status,
+	}
+
+	metadataJSON, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	metadataPath := imagePath + ".json"
+	if err := os.WriteFile(metadataPath, metadataJSON, 0644); err != nil {
+		return fmt.Errorf("failed to write metadata file: %w", err)
+	}
+
+	c.logger.Info("Saved metadata file", map[string]interface{}{
+		"trace_id":      msg.TraceID,
+		"metadata_path": metadataPath,
+	})
+
+	return nil
+}

--- a/services/filewatcher/internal/processor/processor.go
+++ b/services/filewatcher/internal/processor/processor.go
@@ -1,0 +1,218 @@
+package processor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shabohin/photo-tags/pkg/logging"
+	"github.com/shabohin/photo-tags/pkg/messaging"
+	"github.com/shabohin/photo-tags/pkg/models"
+	"github.com/shabohin/photo-tags/pkg/storage"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/config"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/statistics"
+)
+
+// Processor handles file processing
+type Processor struct {
+	cfg      *config.Config
+	logger   *logging.Logger
+	minio    storage.MinIOInterface
+	rabbitmq messaging.RabbitMQInterface
+	stats    *statistics.Statistics
+}
+
+// NewProcessor creates a new Processor instance
+func NewProcessor(
+	cfg *config.Config,
+	logger *logging.Logger,
+	minio storage.MinIOInterface,
+	rabbitmq messaging.RabbitMQInterface,
+	stats *statistics.Statistics,
+) *Processor {
+	return &Processor{
+		cfg:      cfg,
+		logger:   logger,
+		minio:    minio,
+		rabbitmq: rabbitmq,
+		stats:    stats,
+	}
+}
+
+// ProcessFile processes a single file
+func (p *Processor) ProcessFile(ctx context.Context, filePath string) error {
+	traceID := uuid.New().String()
+
+	p.logger.Info("Processing file", map[string]interface{}{
+		"trace_id": traceID,
+		"file":     filePath,
+	})
+
+	// Validate file
+	if err := p.validateFile(filePath); err != nil {
+		p.stats.AddError(fmt.Sprintf("Validation failed: %v", err), traceID)
+		p.stats.IncrementFailed()
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	// Read file
+	fileData, err := os.ReadFile(filePath)
+	if err != nil {
+		p.stats.AddError(fmt.Sprintf("Failed to read file: %v", err), traceID)
+		p.stats.IncrementFailed()
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	// Upload to MinIO
+	filename := filepath.Base(filePath)
+	objectName := fmt.Sprintf("filewatcher/%s/%s", time.Now().Format("2006-01-02"), filename)
+
+	if err := p.minio.UploadFile(ctx, storage.BucketOriginal, objectName, fileData); err != nil {
+		p.stats.AddError(fmt.Sprintf("Failed to upload to MinIO: %v", err), traceID)
+		p.stats.IncrementFailed()
+		return fmt.Errorf("failed to upload to MinIO: %w", err)
+	}
+
+	p.logger.Info("Uploaded to MinIO", map[string]interface{}{
+		"trace_id":    traceID,
+		"bucket":      storage.BucketOriginal,
+		"object_name": objectName,
+	})
+
+	// Create ImageUpload message
+	message := models.ImageUpload{
+		Timestamp:        time.Now(),
+		TraceID:          traceID,
+		GroupID:          "filewatcher",
+		TelegramUsername: "filewatcher",
+		OriginalFilename: filename,
+		OriginalPath:     objectName,
+		TelegramID:       0, // Not from Telegram
+	}
+
+	// Publish to RabbitMQ
+	if err := p.rabbitmq.PublishMessage(messaging.QueueImageUpload, message); err != nil {
+		p.stats.AddError(fmt.Sprintf("Failed to publish to RabbitMQ: %v", err), traceID)
+		p.stats.IncrementFailed()
+		return fmt.Errorf("failed to publish to RabbitMQ: %w", err)
+	}
+
+	p.logger.Info("Published to RabbitMQ", map[string]interface{}{
+		"trace_id": traceID,
+		"queue":    messaging.QueueImageUpload,
+	})
+
+	// Mark as processed
+	if err := p.markAsProcessed(filePath); err != nil {
+		p.logger.Error("Failed to mark file as processed", err)
+		// Don't fail the entire operation if we can't move the file
+	}
+
+	p.stats.IncrementProcessed()
+	p.stats.IncrementSuccessful()
+
+	return nil
+}
+
+// ProcessBatch processes all files in the input directory
+func (p *Processor) ProcessBatch(ctx context.Context) error {
+	p.logger.Info("Starting batch processing", map[string]interface{}{
+		"input_dir": p.cfg.InputDir,
+	})
+
+	files, err := os.ReadDir(p.cfg.InputDir)
+	if err != nil {
+		return fmt.Errorf("failed to read input directory: %w", err)
+	}
+
+	processedCount := 0
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		filePath := filepath.Join(p.cfg.InputDir, file.Name())
+		if !p.isValidExtension(file.Name()) {
+			continue
+		}
+
+		if err := p.ProcessFile(ctx, filePath); err != nil {
+			p.logger.Error("Failed to process file", err)
+			continue
+		}
+		processedCount++
+	}
+
+	p.logger.Info("Batch processing completed", map[string]interface{}{
+		"files_processed": processedCount,
+	})
+
+	return nil
+}
+
+// validateFile validates the file format and size
+func (p *Processor) validateFile(filePath string) error {
+	// Check extension
+	if !p.isValidExtension(filePath) {
+		return fmt.Errorf("invalid file extension")
+	}
+
+	// Check file size
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	maxSize := p.cfg.MaxFileSizeMB * 1024 * 1024
+	if info.Size() > maxSize {
+		return fmt.Errorf("file too large: %d bytes (max: %d bytes)", info.Size(), maxSize)
+	}
+
+	return nil
+}
+
+// isValidExtension checks if the file has a valid extension
+func (p *Processor) isValidExtension(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	for _, allowed := range p.cfg.AllowedExtensions {
+		if strings.ToLower(allowed) == ext {
+			return true
+		}
+	}
+	return false
+}
+
+// markAsProcessed moves the file to the processed directory or deletes it
+func (p *Processor) markAsProcessed(filePath string) error {
+	// Create processed directory if it doesn't exist
+	if err := os.MkdirAll(p.cfg.ProcessedDir, 0755); err != nil {
+		return fmt.Errorf("failed to create processed directory: %w", err)
+	}
+
+	// Move file to processed directory
+	filename := filepath.Base(filePath)
+	processedPath := filepath.Join(p.cfg.ProcessedDir, filename)
+
+	// If file already exists in processed dir, append timestamp
+	if _, err := os.Stat(processedPath); err == nil {
+		timestamp := time.Now().Format("20060102-150405")
+		ext := filepath.Ext(filename)
+		nameWithoutExt := strings.TrimSuffix(filename, ext)
+		processedPath = filepath.Join(p.cfg.ProcessedDir, fmt.Sprintf("%s_%s%s", nameWithoutExt, timestamp, ext))
+	}
+
+	if err := os.Rename(filePath, processedPath); err != nil {
+		return fmt.Errorf("failed to move file to processed directory: %w", err)
+	}
+
+	p.logger.Info("Marked file as processed", map[string]interface{}{
+		"original_path":  filePath,
+		"processed_path": processedPath,
+	})
+
+	return nil
+}

--- a/services/filewatcher/internal/statistics/statistics.go
+++ b/services/filewatcher/internal/statistics/statistics.go
@@ -1,0 +1,102 @@
+package statistics
+
+import (
+	"sync"
+	"time"
+)
+
+// Statistics tracks processing statistics
+type Statistics struct {
+	mu                sync.RWMutex
+	FilesProcessed    int64     `json:"files_processed"`
+	FilesSuccessful   int64     `json:"files_successful"`
+	FilesFailed       int64     `json:"files_failed"`
+	FilesReceived     int64     `json:"files_received"`
+	LastProcessedTime time.Time `json:"last_processed_time"`
+	StartTime         time.Time `json:"start_time"`
+	Errors            []Error   `json:"recent_errors"`
+	maxErrors         int
+}
+
+// Error represents an error that occurred during processing
+type Error struct {
+	Timestamp time.Time `json:"timestamp"`
+	Message   string    `json:"message"`
+	TraceID   string    `json:"trace_id,omitempty"`
+}
+
+// NewStatistics creates a new Statistics instance
+func NewStatistics() *Statistics {
+	return &Statistics{
+		StartTime: time.Now(),
+		Errors:    make([]Error, 0, 10),
+		maxErrors: 10,
+	}
+}
+
+// IncrementProcessed increments the files processed counter
+func (s *Statistics) IncrementProcessed() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.FilesProcessed++
+	s.LastProcessedTime = time.Now()
+}
+
+// IncrementSuccessful increments the successful files counter
+func (s *Statistics) IncrementSuccessful() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.FilesSuccessful++
+}
+
+// IncrementFailed increments the failed files counter
+func (s *Statistics) IncrementFailed() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.FilesFailed++
+}
+
+// IncrementReceived increments the received files counter
+func (s *Statistics) IncrementReceived() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.FilesReceived++
+}
+
+// AddError adds an error to the statistics
+func (s *Statistics) AddError(message, traceID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	err := Error{
+		Timestamp: time.Now(),
+		Message:   message,
+		TraceID:   traceID,
+	}
+
+	// Keep only last N errors
+	s.Errors = append(s.Errors, err)
+	if len(s.Errors) > s.maxErrors {
+		s.Errors = s.Errors[len(s.Errors)-s.maxErrors:]
+	}
+}
+
+// GetSnapshot returns a snapshot of current statistics
+func (s *Statistics) GetSnapshot() Statistics {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Create a copy to avoid race conditions
+	errorsCopy := make([]Error, len(s.Errors))
+	copy(errorsCopy, s.Errors)
+
+	return Statistics{
+		FilesProcessed:    s.FilesProcessed,
+		FilesSuccessful:   s.FilesSuccessful,
+		FilesFailed:       s.FilesFailed,
+		FilesReceived:     s.FilesReceived,
+		LastProcessedTime: s.LastProcessedTime,
+		StartTime:         s.StartTime,
+		Errors:            errorsCopy,
+	}
+}

--- a/services/filewatcher/internal/watcher/watcher.go
+++ b/services/filewatcher/internal/watcher/watcher.go
@@ -1,0 +1,201 @@
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/shabohin/photo-tags/pkg/logging"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/config"
+	"github.com/shabohin/photo-tags/services/filewatcher/internal/processor"
+)
+
+// Watcher monitors the input directory for new files
+type Watcher struct {
+	cfg       *config.Config
+	logger    *logging.Logger
+	processor *processor.Processor
+}
+
+// NewWatcher creates a new Watcher instance
+func NewWatcher(
+	cfg *config.Config,
+	logger *logging.Logger,
+	processor *processor.Processor,
+) *Watcher {
+	return &Watcher{
+		cfg:       cfg,
+		logger:    logger,
+		processor: processor,
+	}
+}
+
+// Start starts watching the input directory
+func (w *Watcher) Start(ctx context.Context) error {
+	// Ensure input directory exists
+	if err := os.MkdirAll(w.cfg.InputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create input directory: %w", err)
+	}
+
+	if w.cfg.UseFsnotify {
+		return w.watchWithFsnotify(ctx)
+	}
+	return w.watchWithPolling(ctx)
+}
+
+// watchWithFsnotify uses fsnotify to watch for file system events
+func (w *Watcher) watchWithFsnotify(ctx context.Context) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create fsnotify watcher: %w", err)
+	}
+	defer watcher.Close()
+
+	// Add input directory to watcher
+	if err := watcher.Add(w.cfg.InputDir); err != nil {
+		return fmt.Errorf("failed to add directory to watcher: %w", err)
+	}
+
+	w.logger.Info("Started watching directory with fsnotify", map[string]interface{}{
+		"directory": w.cfg.InputDir,
+	})
+
+	// Track recently processed files to avoid duplicate processing
+	recentlyProcessed := make(map[string]time.Time)
+	cleanupTicker := time.NewTicker(1 * time.Minute)
+	defer cleanupTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+
+			// Only process Create and Write events
+			if event.Op&fsnotify.Create == fsnotify.Create || event.Op&fsnotify.Write == fsnotify.Write {
+				// Check if file was recently processed
+				if lastProcessed, exists := recentlyProcessed[event.Name]; exists {
+					if time.Since(lastProcessed) < 5*time.Second {
+						continue
+					}
+				}
+
+				// Wait a bit to ensure file is completely written
+				time.Sleep(100 * time.Millisecond)
+
+				// Process the file
+				if err := w.processor.ProcessFile(ctx, event.Name); err != nil {
+					w.logger.Error("Failed to process file", err)
+				} else {
+					recentlyProcessed[event.Name] = time.Now()
+				}
+			}
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			w.logger.Error("Watcher error", err)
+
+		case <-cleanupTicker.C:
+			// Clean up old entries from recentlyProcessed
+			cutoff := time.Now().Add(-5 * time.Minute)
+			for path, t := range recentlyProcessed {
+				if t.Before(cutoff) {
+					delete(recentlyProcessed, path)
+				}
+			}
+		}
+	}
+}
+
+// watchWithPolling uses polling to check for new files
+func (w *Watcher) watchWithPolling(ctx context.Context) error {
+	w.logger.Info("Started watching directory with polling", map[string]interface{}{
+		"directory": w.cfg.InputDir,
+		"interval":  w.cfg.ScanInterval,
+	})
+
+	ticker := time.NewTicker(w.cfg.ScanInterval)
+	defer ticker.Stop()
+
+	// Keep track of known files to avoid reprocessing
+	knownFiles := make(map[string]bool)
+
+	// Initial scan
+	if err := w.scanDirectory(ctx, knownFiles); err != nil {
+		w.logger.Error("Initial scan failed", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case <-ticker.C:
+			if err := w.scanDirectory(ctx, knownFiles); err != nil {
+				w.logger.Error("Scan failed", err)
+			}
+		}
+	}
+}
+
+// scanDirectory scans the input directory for new files
+func (w *Watcher) scanDirectory(ctx context.Context, knownFiles map[string]bool) error {
+	files, err := os.ReadDir(w.cfg.InputDir)
+	if err != nil {
+		return fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		filePath := filepath.Join(w.cfg.InputDir, file.Name())
+
+		// Skip if already known
+		if knownFiles[filePath] {
+			continue
+		}
+
+		// Process the file
+		if err := w.processor.ProcessFile(ctx, filePath); err != nil {
+			w.logger.Error("Failed to process file", err)
+			continue
+		}
+
+		// Mark as known (but it's already moved to processed dir)
+		knownFiles[filePath] = true
+	}
+
+	// Clean up knownFiles map periodically
+	if len(knownFiles) > 1000 {
+		// Keep only the last 500 entries
+		count := 0
+		for k := range knownFiles {
+			if count < len(knownFiles)-500 {
+				delete(knownFiles, k)
+			}
+			count++
+		}
+	}
+
+	return nil
+}
+
+// TriggerManualScan triggers a manual scan of the input directory
+func (w *Watcher) TriggerManualScan(ctx context.Context) error {
+	w.logger.Info("Manual scan triggered", map[string]interface{}{
+		"directory": w.cfg.InputDir,
+	})
+
+	return w.processor.ProcessBatch(ctx)
+}


### PR DESCRIPTION
Implemented a new File Watcher Service that monitors directories for images and processes them through the photo-tags pipeline without requiring the Telegram bot interface.

Features:
- File system monitoring using fsnotify or polling (configurable)
- Automatic upload to MinIO and publishing to RabbitMQ
- Result consumption from RabbitMQ and saving to output directory
- REST API with /health, /stats, and /scan endpoints
- Statistics tracking (processed, successful, failed files)
- Metadata export as JSON files alongside images
- Graceful shutdown handling
- Comprehensive error logging with trace IDs

Configuration:
- INPUT_DIR: Directory to watch for new images
- OUTPUT_DIR: Directory to save processed images
- PROCESSED_DIR: Directory for processed originals
- SCAN_INTERVAL_SECONDS: Polling interval (default: 5s)
- USE_FSNOTIFY: Enable fsnotify (default: true)
- MAX_FILE_SIZE_MB: Maximum file size (default: 50MB)

Usage:
- Copy images to input directory
- Monitor via http://localhost:8081/stats
- Retrieve processed images from output directory
- Trigger manual scan via POST /scan

This enables batch processing of images and integration with automated workflows without requiring Telegram interaction.